### PR TITLE
Update wrangler command to deploy the worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ wrangler secret put TOKEN_DEMO
 Deployment to the world-wide-web is simple.
 
 1. `cd server && npm i`
-2. `wrangler publish`
+2. `wrangler deploy`
 
 ## Running The Client
 


### PR DESCRIPTION
 `wrangler publish` is deprecated and will be removed in the next major version.
Please use `wrangler deploy` instead, which accepts exactly the same
  arguments.